### PR TITLE
WIP: Implement a safe builder pattern

### DIFF
--- a/example/src/main/java/io/norberg/automatter/example/SimpleExample.java
+++ b/example/src/main/java/io/norberg/automatter/example/SimpleExample.java
@@ -21,5 +21,8 @@ public class SimpleExample {
         .build();
 
     out.println("modified: " + modified);
+
+    Foobar safeFoobar = FoobarBuilder.SafeBuilder.safeBuild(builder -> builder.bar(3).foo("foo"));
+    out.println("safe: " + safeFoobar);
   }
 }


### PR DESCRIPTION
with compile time checks of required fields.

From http://www.radicaljava.com/2016/09/19/safe-builder.html

WIP:
- No tests, only one sample
- Expected output not updated (how is that done?)
- Some todos in type naming (correct upper casing etc)
- The safe setter reserves the variable name "retypedThis", safe builder reserves a few marker interface names "Defined", "<Field>Defined", "<Field>NotDefined".
- Usage entry point should be different.

Right now, it's:
  `TypeBuilder.SafeBuilder.safeBuild(builder -> builder.a(a).b(b))`

Sample error message:
    `Foobar safeFoobar = FoobarBuilder.SafeBuilder.safeBuild(builder -> builder.foo("foo")); // missing bar`
gives the error:
    `Bad return type in lambda expression: SafeBuilder<FooDefined, BarNotDefined> cannot be converted to SafeBuilder<FooDefined, BarDefined>`
